### PR TITLE
Fixing artwork variable WidgetFanart

### DIFF
--- a/1080i/Includes_Views.xml
+++ b/1080i/Includes_Views.xml
@@ -441,9 +441,9 @@
 		<value>$INFO[ListItem.Icon]</value>
 	</variable>
 	<variable name="WidgetFanart">
+		<value condition="!String.IsEmpty(ListItem.Art(fanart))">$INFO[ListItem.Art(fanart)]</value>
 		<value condition="!String.IsEmpty(ListItem.Art(landscape))">$INFO[ListItem.Art(landscape)]</value>
 		<value condition="!String.IsEmpty(ListItem.Art(tvshow.landscape))">$INFO[ListItem.Art(tvshow.landscape)]</value>
-		<value condition="!String.IsEmpty(ListItem.Art(fanart))">$INFO[ListItem.Art(fanart)]</value>
 		<value>$INFO[ListItem.Icon]</value>
 	</variable>
 


### PR DESCRIPTION
The WidgetFanart uses landscape first, and landscape in Emby is the "Thumb" which is too small a resolution to look nice. Simple fix it seems to me and the fanart is better suited anyway.