### PR TITLE
new dialog - osdsubtitlesettings

### DIFF
--- a/1080i/DialogSettings.xml
+++ b/1080i/DialogSettings.xml
@@ -2,7 +2,7 @@
 <window>
     <defaultcontrol>5</defaultcontrol>
     <controls>
-        <include condition="!Window.IsActive(osdvideosettings) + !Window.IsActive(osdaudiosettings)">DialogSettings</include>
-        <include condition="[Window.IsActive(osdvideosettings) | Window.IsActive(osdaudiosettings)]">OSDDialogSettings</include>
+        <include condition="!Window.IsActive(osdsubtitlesettings) + !Window.IsActive(osdvideosettings) + !Window.IsActive(osdaudiosettings)">DialogSettings</include>
+        <include condition="[Window.IsActive(osdsubtitlesettings) | Window.IsActive(osdvideosettings) | Window.IsActive(osdaudiosettings)]">OSDDialogSettings</include>
     </controls>
 </window>

--- a/1080i/Includes_DialogSettings.xml
+++ b/1080i/Includes_DialogSettings.xml
@@ -2,7 +2,7 @@
 <includes>
         <include name="OSDDialogSettings">
             <control type="group">
-                <visible>!Window.IsVisible(sliderdialog) + !Window.IsVisible(filebrowser)</visible>
+                <visible>!Window.IsVisible(DialogSubtitles.xml) + !Window.IsVisible(sliderdialog) + !Window.IsVisible(filebrowser)</visible>
                 <posx>0</posx>
                 <posy>0</posy>
                 <include>NowPlayingFullscreen</include>

--- a/1080i/VideoOSD.xml
+++ b/1080i/VideoOSD.xml
@@ -99,7 +99,7 @@
                         <texturenofocus>osd/fullscreen/buttons/subtitles-nofo.png</texturenofocus>
                         <alttexturefocus>osd/fullscreen/buttons/subtitles-fo.png</alttexturefocus>
                         <alttexturenofocus>osd/fullscreen/buttons/subtitles-nofo.png</alttexturenofocus>
-                        <onclick>ActivateWindow(SubtitleSearch)</onclick>
+                        <onclick>ActivateWindow(10159)</onclick>
                         <onleft>12</onleft>
                         <onright>1</onright>
                         <onup>Close</onup>


### PR DESCRIPTION
OSD Subtitle Settings in Leia are now in a seperate dialog and are not accessible via the audiosettings dialog anymore.

https://forum.kodi.tv/showthread.php?tid=298565&pid=2705599#pid2705599

Since the new dialog now includes a "download subtitles" option, i changed the default subtitle button in the video osd to this new dialog.