### PR TITLE
Remove include of obsolete guide views

### DIFF
--- a/1080i/Includes_Views.xml
+++ b/1080i/Includes_Views.xml
@@ -13,7 +13,6 @@
     <include file="ViewtypesPictures.xml"/>
     <include file="ViewtypesPrograms.xml"/>
     <include file="ViewtypesAddons.xml"/>
-    <include file="ViewtypesPVRGuide.xml"/>
     <include name="VideoViews">
         <include>Viewtype-List</include>
         <include>Viewtype-InfoList</include>


### PR DESCRIPTION
As of commit 21e46255ac346c7f325fc83ae6ed2422c90d3fe9, the file `1080i/ViewtypesPVRGuide.xml` but it was still included in `1080i/Include_Views.xml` and thus keeps generating errors.