### PR TITLE
Initial support for Kodi 21.x (Omega)

### DIFF
--- a/1080i/DialogAddonInfo.xml
+++ b/1080i/DialogAddonInfo.xml
@@ -147,7 +147,7 @@
                         <width>440</width>
                         <height>247</height>
                         <onleft condition="!Window.IsVisible(3008)">SetProperty(BounceLeft,1,Home)</onleft>
-                        <onright>9334</onright>
+                        <onright>9333</onright>
                         <onup>9333</onup>
                         <ondown>9333</ondown>
                         <scrolltime tween="cubic" easing="out">500</scrolltime>

--- a/1080i/DialogContextMenu.xml
+++ b/1080i/DialogContextMenu.xml
@@ -2,11 +2,11 @@
 <window>
     <defaultcontrol always="true">996</defaultcontrol>
     <include>OpenCloseAnimationContext</include>
-    <include condition="Window.IsVisible(favourites) | [!Window.IsVisible(videobookmarks) + !Window.IsVisible(filemanager) + !Window.IsVisible(musicplaylisteditor) + !Window.IsVisible(LockSettings) + !Window.IsVisible(addoninformation) + !Window.IsVisible(home) + !Window.IsVisible(pvrchannelmanager)]">ContextCoordinates</include>
+    <include condition="Window.IsVisible(favouritesbrowser) | [!Window.IsVisible(videobookmarks) + !Window.IsVisible(filemanager) + !Window.IsVisible(musicplaylisteditor) + !Window.IsVisible(LockSettings) + !Window.IsVisible(addoninformation) + !Window.IsVisible(home) + !Window.IsVisible(pvrchannelmanager)]">ContextCoordinates</include>
     <animation effect="slide" end="0,256" time="0" condition="Window.IsVisible(LockSettings)">Conditional</animation>
     <controls>
-        <include condition="Window.IsVisible(favourites) | [!Window.IsVisible(videobookmarks) + !Window.IsVisible(filemanager) + !Window.IsVisible(musicplaylisteditor) + !Window.IsVisible(LockSettings) + !Window.IsVisible(addoninformation) + !Window.IsVisible(home) + !Window.IsVisible(pvrchannelmanager)]">ContextMenuDefault</include>
-        <include condition="Window.IsVisible(home) + !Window.IsVisible(favourites)">ContextMenuHome</include>
+        <include condition="Window.IsVisible(favouritesbrowser) | [!Window.IsVisible(videobookmarks) + !Window.IsVisible(filemanager) + !Window.IsVisible(musicplaylisteditor) + !Window.IsVisible(LockSettings) + !Window.IsVisible(addoninformation) + !Window.IsVisible(home) + !Window.IsVisible(pvrchannelmanager)]">ContextMenuDefault</include>
+        <include condition="Window.IsVisible(home) + !Window.IsVisible(favouritesbrowser)">ContextMenuHome</include>
         <include condition="Window.IsVisible(LockSettings) | Window.IsVisible(pvrchannelmanager)">ContextMenuPVRChannelManager</include>
         <include condition="Window.IsVisible(filemanager) | Window.IsVisible(musicplaylisteditor)">ContextMenuFileManager</include>
         <include condition="Window.IsVisible(addoninformation)">ContextMenuAddonInfo</include>

--- a/1080i/EventLog.xml
+++ b/1080i/EventLog.xml
@@ -9,7 +9,7 @@
             <include>EventLogHeader</include>
 
             <control type="group">
-                <visible>!Window.IsActive(favourites)</visible>
+                <visible>!Window.IsActive(favouritesbrowser)</visible>
                 <include>CommonViewAnimations</include>
                 <include>OptionsShutdownAnimation</include>
                 <control type="image">

--- a/1080i/FileManager.xml
+++ b/1080i/FileManager.xml
@@ -20,7 +20,7 @@
                     <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                     <effect type="zoom" start="100" end="85" time="300" center="960,600" tween="sine" easing="out" />
                 </animation>
-                <visible>!Window.IsActive(favourites)</visible>
+                <visible>!Window.IsActive(favouritesbrowser)</visible>
                 <!-- Left -->
                 <control type="group">
                     <posx>200</posx>

--- a/1080i/Includes_Animations.xml
+++ b/1080i/Includes_Animations.xml
@@ -41,11 +41,11 @@
     </include>
 
     <include name="OpenCloseAnimationContext">
-        <animation type="WindowOpen" condition="Window.IsVisible(favourites) | [!Window.IsVisible(addoninformation) + !Window.IsVisible(home) + !Window.IsVisible(filemanager) + !Window.IsVisible(LockSettings) + !Window.IsVisible(musicplaylisteditor) + !Window.IsVisible(DialogPVRChannelManager.xml)]">
+        <animation type="WindowOpen" condition="Window.IsVisible(favouritesbrowser) | [!Window.IsVisible(addoninformation) + !Window.IsVisible(home) + !Window.IsVisible(filemanager) + !Window.IsVisible(LockSettings) + !Window.IsVisible(musicplaylisteditor) + !Window.IsVisible(DialogPVRChannelManager.xml)]">
             <effect type="fade" start="0" end="100" time="200" tween="sine" easing="in"  />
             <effect type="slide" start="0,0" end="0,-40" time="300" delay="100" tween="sine" easing="out" />
         </animation>
-        <animation type="WindowClose" condition="!Window.IsVisible(favourites) | [!Window.IsVisible(addoninformation) + !Window.IsVisible(home) + !Window.IsVisible(filemanager) + !Window.IsVisible(LockSettings) + !Window.IsVisible(musicplaylisteditor) + !Window.IsVisible(DialogPVRChannelManager.xml)]">
+        <animation type="WindowClose" condition="!Window.IsVisible(favouritesbrowser) | [!Window.IsVisible(addoninformation) + !Window.IsVisible(home) + !Window.IsVisible(filemanager) + !Window.IsVisible(LockSettings) + !Window.IsVisible(musicplaylisteditor) + !Window.IsVisible(DialogPVRChannelManager.xml)]">
             <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
             <effect type="slide" start="0,-40" end="0,-40" time="300" />
         </animation>
@@ -408,11 +408,11 @@
             <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
             <effect type="zoom" start="100" end="75" time="300" center="auto" tween="sine" easing="out" />
         </animation>
-        <animation type="Conditional" condition="!Window.IsActive(movieinformation) + !Window.IsActive(musicinformation) + !Window.IsActive(1122) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(favourites)" reversible="false">
+        <animation type="Conditional" condition="!Window.IsActive(movieinformation) + !Window.IsActive(musicinformation) + !Window.IsActive(1122) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(favouritesbrowser)" reversible="false">
             <effect type="fade" start="0" end="100" time="300" delay="350" tween="sine" easing="in" />
             <effect type="zoom" start="115" end="100" time="300" delay="350" center="auto" tween="sine" easing="out" />
         </animation>
-        <animation type="Conditional" condition="Window.IsActive(movieinformation) | Window.IsActive(musicinformation) | Window.IsActive(1122) | Window.IsActive(script-script.extendedinfo-DialogInfo.xml) | Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) | Window.IsActive(favourites)" reversible="false">
+        <animation type="Conditional" condition="Window.IsActive(movieinformation) | Window.IsActive(musicinformation) | Window.IsActive(1122) | Window.IsActive(script-script.extendedinfo-DialogInfo.xml) | Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) | Window.IsActive(favouritesbrowser)" reversible="false">
             <effect type="zoom" start="100" end="115" center="auto" tween="sine" delay="0" easing="out" time="300" />
             <effect type="fade" start="100" end="0" tween="cubic" easing="out" delay="0" time="300" />
         </animation>

--- a/1080i/Includes_Commons.xml
+++ b/1080i/Includes_Commons.xml
@@ -129,7 +129,7 @@
                 <height>100</height>
                 <texture>$VAR[OptionsMenuButtonTexture]</texture>
                 <include>homebuttonsanim3</include>
-                <visible>!Window.IsActive(DialogPVRInfo.xml) + !Window.IsVisible(movieinformation) + !Window.IsVisible(script-script.extendedinfo-DialogInfo.xml) + !Window.IsVisible(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsVisible(addoninformation) + !Window.IsVisible(musicinformation) + !Window.IsVisible(songinformation) + !Window.IsVisible(1122) + !Window.IsActive(favourites)</visible>
+                <visible>!Window.IsActive(DialogPVRInfo.xml) + !Window.IsVisible(movieinformation) + !Window.IsVisible(script-script.extendedinfo-DialogInfo.xml) + !Window.IsVisible(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsVisible(addoninformation) + !Window.IsVisible(musicinformation) + !Window.IsVisible(songinformation) + !Window.IsVisible(1122) + !Window.IsActive(favouritesbrowser)</visible>
             </control>
             <control type="label">
                 <description>Options Label</description>
@@ -142,7 +142,7 @@
                 <textcolor>eewhite</textcolor>
                 <shadowcolor>22000000</shadowcolor>
                 <include>homebuttonsanim4</include>
-                <visible>!Window.IsActive(DialogPVRInfo.xml) + !Window.IsVisible(movieinformation) + !Window.IsVisible(script-script.extendedinfo-DialogInfo.xml) + !Window.IsVisible(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsVisible(addoninformation) + !Window.IsVisible(musicinformation) + !Window.IsVisible(songinformation) + !Window.IsVisible(1122) + !Window.IsActive(favourites)</visible>
+                <visible>!Window.IsActive(DialogPVRInfo.xml) + !Window.IsVisible(movieinformation) + !Window.IsVisible(script-script.extendedinfo-DialogInfo.xml) + !Window.IsVisible(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsVisible(addoninformation) + !Window.IsVisible(musicinformation) + !Window.IsVisible(songinformation) + !Window.IsVisible(1122) + !Window.IsActive(favouritesbrowser)</visible>
             </control>
         </control>
     </include>

--- a/1080i/Includes_HomeCommons.xml
+++ b/1080i/Includes_HomeCommons.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <includes>
-    <expression name="HomeHideOnActiveDialog">!Window.IsActive(movieinformation) + !Window.IsActive(musicinformation) + !Window.IsActive(favourites) + !Window.IsActive(script-globalsearch.xml) + ![Window.IsVisible(virtualkeyboard) + !String.IsEmpty(Window.Property(HomeSearch))]</expression>
+    <expression name="HomeHideOnActiveDialog">!Window.IsActive(movieinformation) + !Window.IsActive(musicinformation) + !Window.IsActive(favouritesbrowser) + !Window.IsActive(script-globalsearch.xml) + ![Window.IsVisible(virtualkeyboard) + !String.IsEmpty(Window.Property(HomeSearch))]</expression>
 
     <include name="FocusPosition">
         <focusposition>$PARAM[value]</focusposition>
@@ -81,7 +81,7 @@
                 <onclick>ActivateWindow(ShutdownMenu)</onclick>
                 <include>Animation_ShutdownButton</include>
                 <include>homebuttonsanim</include>
-                <visible allowhiddenfocus="true">!Window.IsVisible(favourites) + !Window.IsVisible(script-globalsearch.xml) + !Window.IsVisible(virtualkeyboard) + String.IsEmpty(Window.Property(HomeSearch)) + !Window.IsVisible(playercontrols) + !Window.IsActive(movieinformation)</visible>
+                <visible allowhiddenfocus="true">!Window.IsVisible(favouritesbrowser) + !Window.IsVisible(script-globalsearch.xml) + !Window.IsVisible(virtualkeyboard) + String.IsEmpty(Window.Property(HomeSearch)) + !Window.IsVisible(playercontrols) + !Window.IsActive(movieinformation)</visible>
             </control>
             <control type="label">
                 <description>Shutdown Label</description>
@@ -96,7 +96,7 @@
                 <scroll>false</scroll>
                 <include>Animation_ShutdownButton</include>
                 <include>homebuttonsanim2</include>
-                <visible>!Window.IsVisible(favourites) + !Window.IsVisible(script-globalsearch.xml) + !Window.IsVisible(virtualkeyboard) + String.IsEmpty(Window.Property(HomeSearch)) + !Window.IsVisible(playercontrols) + !Window.IsActive(movieinformation)</visible>
+                <visible>!Window.IsVisible(favouritesbrowser) + !Window.IsVisible(script-globalsearch.xml) + !Window.IsVisible(virtualkeyboard) + String.IsEmpty(Window.Property(HomeSearch)) + !Window.IsVisible(playercontrols) + !Window.IsActive(movieinformation)</visible>
             </control>
             <control type="button" id="22">
                 <description>Favourites Button</description>
@@ -128,11 +128,11 @@
                 <onright>21</onright>
                 <texturefocus>buttons/favourites_fo.png</texturefocus>
                 <texturenofocus>buttons/favourites_nofo.png</texturenofocus>
-                <onclick>ActivateWindow(Favourites)</onclick>
+                <onclick>ActivateWindow(favouritesbrowser)</onclick>
                 <include>Animation_FavButton</include>
                 <include>homebuttonsanim3</include>
                 <visible>!Skin.HasSetting(KioskMode)</visible>
-                <visible allowhiddenfocus="true">!Window.IsVisible(favourites) + !Window.IsVisible(script-globalsearch.xml) + !Window.IsVisible(virtualkeyboard) + String.IsEmpty(Window.Property(HomeSearch)) + !Window.IsVisible(playercontrols) + !Window.IsActive(movieinformation)</visible>
+                <visible allowhiddenfocus="true">!Window.IsVisible(favouritesbrowser) + !Window.IsVisible(script-globalsearch.xml) + !Window.IsVisible(virtualkeyboard) + String.IsEmpty(Window.Property(HomeSearch)) + !Window.IsVisible(playercontrols) + !Window.IsActive(movieinformation)</visible>
             </control>
             <control type="label">
                 <description>Favourites Label</description>
@@ -148,7 +148,7 @@
                 <include>Animation_FavButton</include>
                 <include>homebuttonsanim4</include>
                 <visible>!Skin.HasSetting(KioskMode)</visible>
-                <visible>!Window.IsVisible(favourites) + !Window.IsVisible(script-globalsearch.xml) + !Window.IsVisible(virtualkeyboard) + String.IsEmpty(Window.Property(HomeSearch)) + !Window.IsVisible(playercontrols) + !Window.IsActive(movieinformation)</visible>
+                <visible>!Window.IsVisible(favouritesbrowser) + !Window.IsVisible(script-globalsearch.xml) + !Window.IsVisible(virtualkeyboard) + String.IsEmpty(Window.Property(HomeSearch)) + !Window.IsVisible(playercontrols) + !Window.IsActive(movieinformation)</visible>
             </control>
         </control>
     </include>

--- a/1080i/Includes_ViewHeader.xml
+++ b/1080i/Includes_ViewHeader.xml
@@ -288,7 +288,7 @@
         <control type="group">
             <posx>75</posx>
             <posy>26</posy>
-            <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(1122) + !Window.IsActive(addoninformation) + !Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(1122) + !Window.IsActive(addoninformation) + !Window.IsActive(favouritesbrowser)</visible>
             <include>BannerListInfoAnimation</include>
             <control type="group">
                 <control type="image">
@@ -340,7 +340,7 @@
         <control type="group">
             <posx>75</posx>
             <posy>26</posy>
-            <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(addoninformation) + !Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(addoninformation) + !Window.IsActive(favouritesbrowser)</visible>
             <include>BannerListInfoAnimation</include>
             <control type="group">
                 <control type="image">
@@ -372,7 +372,7 @@
         <control type="group">
             <posx>75</posx>
             <posy>26</posy>
-            <visible>!Window.IsActive(musicinformation) + !Window.IsActive(addoninformation) + !Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(musicinformation) + !Window.IsActive(addoninformation) + !Window.IsActive(favouritesbrowser)</visible>
             <include>BannerListInfoAnimation</include>
             <control type="image">
                 <include>ViewHeaderIconVars</include>
@@ -422,7 +422,7 @@
         <control type="group">
             <posx>75</posx>
             <posy>26</posy>
-            <visible>!Window.IsActive(addoninformation) + !Window.IsActive(1122) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(addoninformation) + !Window.IsActive(1122) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(favouritesbrowser)</visible>
             <include>BannerListInfoAnimation</include>
             <control type="group">
                 <control type="image">
@@ -464,7 +464,7 @@
         <control type="group">
             <posx>75</posx>
             <posy>26</posy>
-            <visible>!Window.IsActive(addoninformation) + !Window.IsActive(1122) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(addoninformation) + !Window.IsActive(1122) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(favouritesbrowser)</visible>
             <include>BannerListInfoAnimation</include>
             <control type="group">
                 <control type="image">
@@ -506,7 +506,7 @@
         <control type="group">
             <posx>75</posx>
             <posy>26</posy>
-            <visible>!Window.IsActive(addoninformation) + !Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(addoninformation) + !Window.IsActive(favouritesbrowser)</visible>
             <include>BannerListInfoAnimation</include>
             <control type="group">
                 <control type="image">
@@ -548,7 +548,7 @@
         <control type="group">
             <posx>75</posx>
             <posy>26</posy>
-            <visible>!Window.IsActive(addoninformation) + !Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(addoninformation) + !Window.IsActive(favouritesbrowser)</visible>
             <include>BannerListInfoAnimation</include>
             <control type="group">
                 <control type="image">
@@ -590,7 +590,7 @@
         <control type="group">
             <posx>75</posx>
             <posy>26</posy>
-            <visible>!Window.IsActive(addoninformation) + !Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(addoninformation) + !Window.IsActive(favouritesbrowser)</visible>
             <include>BannerListInfoAnimation</include>
             <control type="group">
                 <control type="image">
@@ -659,7 +659,7 @@
         <control type="group">
             <posx>75</posx>
             <posy>26</posy>
-            <visible>!Window.IsActive(musicinformation) + !Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(musicinformation) + !Window.IsActive(favouritesbrowser)</visible>
             <include>BannerListInfoAnimation</include>
             <control type="group">
                 <control type="image">
@@ -688,7 +688,7 @@
         <control type="group">
             <posx>75</posx>
             <posy>26</posy>
-            <visible>!Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(favouritesbrowser)</visible>
             <include>BannerListInfoAnimation</include>
             <control type="group">
                 <control type="image">
@@ -742,7 +742,7 @@
         <control type="group">
             <posx>75</posx>
             <posy>26</posy>
-            <visible>!Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(favouritesbrowser)</visible>
             <include>BannerListInfoAnimation</include>
             <control type="group">
                 <control type="image">
@@ -771,7 +771,7 @@
         <control type="group">
             <posx>75</posx>
             <posy>26</posy>
-            <visible>!Window.IsActive(DialogPVRInfo.xml) + !Window.IsActive(addoninformation) + !Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(DialogPVRInfo.xml) + !Window.IsActive(addoninformation) + !Window.IsActive(favouritesbrowser)</visible>
             <include>BannerListInfoAnimation</include>
             <control type="group">
                 <control type="image">
@@ -900,7 +900,7 @@
         <control type="group">
             <posx>75</posx>
             <posy>26</posy>
-            <visible>!Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(favouritesbrowser)</visible>
             <include>BannerListInfoAnimation</include>
             <control type="group">
                 <control type="image">

--- a/1080i/Includes_Weather.xml
+++ b/1080i/Includes_Weather.xml
@@ -712,7 +712,7 @@
                 <effect type="zoom" start="100" end="50" center="1745,100" tween="sine" easing="inout" time="300" />
             </animation>
             <include>MoonPhaseDummyLabels</include>
-            <visible>Weather.IsFetched + !String.IsEmpty(Window.Property(Today.IsFetched)) + !String.IsEmpty(Window(Weather).Property(Today.moonphase)) + !Window.IsActive(favourites)</visible>
+            <visible>Weather.IsFetched + !String.IsEmpty(Window.Property(Today.IsFetched)) + !String.IsEmpty(Window(Weather).Property(Today.moonphase)) + !Window.IsActive(favouritesbrowser)</visible>
             <control type="group">
                 <control type="image">
                     <posx>0</posx>
@@ -771,7 +771,7 @@
                 <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                 <effect type="zoom" start="100" end="85" time="300" center="960,600" tween="sine" easing="out" />
             </animation>
-            <visible>!Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(favouritesbrowser)</visible>
             <control type="group" id="100">
                 <posy>100</posy>
                 <width>633</width>

--- a/1080i/Includes_WindowContents.xml
+++ b/1080i/Includes_WindowContents.xml
@@ -54,7 +54,7 @@
             <fadetime>500</fadetime>
             <include>Animation_FanartFade</include>
             <texture background="true">$VAR[PlaylistEditorFanart]</texture>
-            <visible>Skin.HasSetting(BackgroundVideo) + Player.HasVideo + !Window.IsActive(favourites)</visible>
+            <visible>Skin.HasSetting(BackgroundVideo) + Player.HasVideo + !Window.IsActive(favouritesbrowser)</visible>
         </control>
         <include>CommonOverlay</include>
     </include>
@@ -72,7 +72,7 @@
             <loop>true</loop>
             <include>Animation_FanartFade</include>
             <imagepath background="true">$VAR[Weather.FanartDir]$INFO[Window(Weather).Property(Current.FanartCode)]</imagepath>
-            <visible>System.HasAddon(resource.images.weatherfanart.multi) + ![Skin.HasSetting(BackgroundVideo) + Player.HasVideo] + Weather.IsFetched + !Window.IsActive(favourites)</visible>
+            <visible>System.HasAddon(resource.images.weatherfanart.multi) + ![Skin.HasSetting(BackgroundVideo) + Player.HasVideo] + Weather.IsFetched + !Window.IsActive(favouritesbrowser)</visible>
         </control>
         <include>CommonOverlay</include>
     </include>
@@ -87,7 +87,7 @@
             <include>Animation_FanartFade</include>
             <fadetime>600</fadetime>
             <texture background="true" fallback=".">$INFO[Container(20).ListItem.property(single)]</texture>
-            <visible>!String.IsEmpty(Container(20).ListItem.property(single)) + ![Skin.HasSetting(BackgroundVideo) + Player.HasVideo] + !Container(20).Scrolling + !Window.IsActive(favourites)</visible>
+            <visible>!String.IsEmpty(Container(20).ListItem.property(single)) + ![Skin.HasSetting(BackgroundVideo) + Player.HasVideo] + !Container(20).Scrolling + !Window.IsActive(favouritesbrowser)</visible>
         </control>
         <control type="multiimage">
             <include>FullscreenDimensions</include>
@@ -97,7 +97,7 @@
             <loop>true</loop>
             <include>Animation_FanartFade</include>
             <imagepath background="true" fallback=".">$INFO[Container(20).ListItem.property(multi)]</imagepath>
-            <visible>!String.IsEmpty(Container(20).ListItem.property(multi)) + ![Skin.HasSetting(BackgroundVideo) + Player.HasVideo] + !Container(20).Scrolling + !Window.IsActive(favourites)</visible>
+            <visible>!String.IsEmpty(Container(20).ListItem.property(multi)) + ![Skin.HasSetting(BackgroundVideo) + Player.HasVideo] + !Container(20).Scrolling + !Window.IsActive(favouritesbrowser)</visible>
         </control>
         <control type="image">
             <description>Search results + video info fanart</description>
@@ -105,7 +105,7 @@
             <texture background="true">$INFO[Window(Home).Property(fanart_image)]</texture>
             <fadetime>500</fadetime>
             <include>Animation_FanartFade</include>
-            <visible>!String.IsEmpty(Window(Home).property(fanart_image)) + ![Skin.HasSetting(BackgroundVideo) + Player.HasVideo] + !Window.IsActive(favourites) + [[!Skin.HasSetting(HideFanart) + Window.IsActive(movieinformation)] | !Window.IsActive(movieinformation)]</visible>
+            <visible>!String.IsEmpty(Window(Home).property(fanart_image)) + ![Skin.HasSetting(BackgroundVideo) + Player.HasVideo] + !Window.IsActive(favouritesbrowser) + [[!Skin.HasSetting(HideFanart) + Window.IsActive(movieinformation)] | !Window.IsActive(movieinformation)]</visible>
         </control>
     </include>
 
@@ -155,7 +155,7 @@
             <texture background="true">$INFO[ListItem.FileNameAndPath]</texture>
             <fadetime>500</fadetime>
             <include>Animation_FanartFade</include>
-            <visible>Window.IsVisible(pictures) + Container.HasFiles + ![Skin.HasSetting(BackgroundVideo) + Player.HasVideo] + !Window.IsActive(favourites)</visible>
+            <visible>Window.IsVisible(pictures) + Container.HasFiles + ![Skin.HasSetting(BackgroundVideo) + Player.HasVideo] + !Window.IsActive(favouritesbrowser)</visible>
         </control>
         <control type="image">
             <description>List Panel fanart</description>
@@ -163,7 +163,7 @@
             <texture background="true">$VAR[ViewFanart]</texture>
             <fadetime>500</fadetime>
             <include>Animation_FanartFade</include>
-            <visible>!Skin.HasSetting(HideFanart) + ![Skin.HasSetting(BackgroundVideo) + Player.HasVideo] + !Window.IsActive(favourites)</visible>
+            <visible>!Skin.HasSetting(HideFanart) + ![Skin.HasSetting(BackgroundVideo) + Player.HasVideo] + !Window.IsActive(favouritesbrowser)</visible>
         </control>
     </include>
     <include name="BackgroundFanartMusicOSD">
@@ -214,7 +214,7 @@
             <texture background="true">fade/overlay.png</texture>
             <animation effect="fade" time="300" start="0" end="100" tween="sine" easing="out">Visible</animation>
             <animation effect="fade" time="300" start="100" end="0" tween="sine" easing="in">Hidden</animation>
-            <visible>[Window.IsActive(songinformation) | Window.IsActive(contentsettings) | Window.IsActive(addonsettings) | Window.IsActive(filebrowser) | [Window.IsActive(virtualkeyboard) + String.IsEmpty(Window(Home).Property(HomeSearch))] | Window.IsActive(playercontrols) | Window.IsActive(profilesettings) | Window.IsActive(selectdialog) | Window.IsActive(progressdialog) | Window.IsActive(mediasource) | Window.IsActive(screencalibration) | Window.IsActive(numericinput) | Window.IsActive(LockSettings) | Window.IsActive(smartplaylisteditor) | Window.IsActive(smartplaylistrule) | Window.IsActive(pictureinfo) | Window.IsActive(script-RSS_Editor-rssEditor.xml) | Window.IsActive(script-RSS_Editor-setEditor.xml) | Window.IsActive(3001) | Window.IsActive(3002) | Window.IsActive(3003) | Window.IsActive(3006) | Window.IsActive(peripheralsettings) | Window.IsActive(mediafilter) | Window.IsActive(mediafilter) | Window.IsActive(pvrgroupmanager) | Window.IsActive(pvrtimersetting) | Window.IsActive(pvrguidesearch) | Window.IsActive(pvrchannelmanager) | Window.IsActive(DialogSelect.xml) | Window.IsActive(yesnodialog) | Window.IsActive(okdialog) | ControlGroup(9000).HasFocus() | [Window.IsActive(contextmenu) + [Window.IsActive(favourites) | [!Window.IsActive(filemanager) + !Window.IsActive(home)]]]] + !Window.IsActive(movieinformation) + !Window.IsActive(1122) + !Window.IsActive(addoninformation) + !Window.IsActive(musicinformation) + !Window.IsActive(musicplaylisteditor) + !Window.IsActive(DialogPVRInfo.xml)</visible>
+            <visible>[Window.IsActive(songinformation) | Window.IsActive(contentsettings) | Window.IsActive(addonsettings) | Window.IsActive(filebrowser) | [Window.IsActive(virtualkeyboard) + String.IsEmpty(Window(Home).Property(HomeSearch))] | Window.IsActive(playercontrols) | Window.IsActive(profilesettings) | Window.IsActive(selectdialog) | Window.IsActive(progressdialog) | Window.IsActive(mediasource) | Window.IsActive(screencalibration) | Window.IsActive(numericinput) | Window.IsActive(LockSettings) | Window.IsActive(smartplaylisteditor) | Window.IsActive(smartplaylistrule) | Window.IsActive(pictureinfo) | Window.IsActive(script-RSS_Editor-rssEditor.xml) | Window.IsActive(script-RSS_Editor-setEditor.xml) | Window.IsActive(3001) | Window.IsActive(3002) | Window.IsActive(3003) | Window.IsActive(3006) | Window.IsActive(peripheralsettings) | Window.IsActive(mediafilter) | Window.IsActive(mediafilter) | Window.IsActive(pvrgroupmanager) | Window.IsActive(pvrtimersetting) | Window.IsActive(pvrguidesearch) | Window.IsActive(pvrchannelmanager) | Window.IsActive(DialogSelect.xml) | Window.IsActive(yesnodialog) | Window.IsActive(okdialog) | ControlGroup(9000).HasFocus() | [Window.IsActive(contextmenu) + [Window.IsActive(favouritesbrowser) | [!Window.IsActive(filemanager) + !Window.IsActive(home)]]]] + !Window.IsActive(movieinformation) + !Window.IsActive(1122) + !Window.IsActive(addoninformation) + !Window.IsActive(musicinformation) + !Window.IsActive(musicplaylisteditor) + !Window.IsActive(DialogPVRInfo.xml)</visible>
         </control>
     </include>
     <include name="FadeBackgroundPVRInfo">

--- a/1080i/MyFavourites.xml
+++ b/1080i/MyFavourites.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<window type="dialog">
+<window>
     <defaultcontrol always="true">450</defaultcontrol>
-    <!--<zorder>-1</zorder>-->
-    <onload condition="String.IsEmpty(Window(Home).Property(Favourites))">SetProperty(Favourites,1,Home)</onload>
-    <onload condition="String.IsEmpty(Window(Home).Property(Favourites))">Control.Move(450,-1)</onload>
-    <onload condition="!Control.IsVisible(63)">PreviousMenu</onload>
+    <menucontrol>9000</menucontrol>
+    <backgroundcolor>0</backgroundcolor>
+    <views>450</views>
     <controls>
+        <include>CommonItems</include>
+        <include>CommonInfo</include>
         <control type="group" id="63">
             <visible>!Window.IsActive(movieinformation) + !Window.IsActive(musicinformation) + !Window.IsActive(songinformation) + !Window.IsActive(addoninformation) + !Window.IsActive(script-globalsearch.xml) + !Window.IsActive(fullscreenvideo) + !Window.IsActive(visualisation) + !Window.IsActive(selectdialog) + !Window.IsActive(filebrowser) + !Window.IsActive(yesnodialog) + !Window.IsActive(progressdialog) + !Window.IsActive(virtualkeyboard) + ![Window.IsActive(contextmenu) + !Control.IsVisible(63)] + !Window.IsActive(numericinput) + !Window.IsActive(playercontrols) + !Window.IsActive(networksetup) + !Window.IsActive(mediasource) + !Window.IsActive(locksettings) + !Window.IsActive(contentsettings) + !Window.IsActive(visualisation) + !Window.IsActive(smartplaylisteditor) + !Window.IsActive(pictureinfo) + !Window.IsActive(addonsettings) + !Window.IsActive(sliderdialog) + !Window.IsActive(textviewer) + !Window.IsActive(mediafilter) + !Window.IsActive(pvrguideinfo) + !Window.IsActive(pvrrecordinginfo) + !Window.IsActive(pvrtimersetting) + !Window.IsActive(pvrgroupmanager) + !Window.IsActive(pvrchannelmanager) + !Window.IsActive(pvrguidesearch) + !Window.IsActive(okdialog) + !Window.IsActive(1122) + !Window.IsActive(3020) + !Window.IsActive(3021) + !Window.IsActive(3022) + !Window.IsActive(3023) + !Window.IsActive(3001) + !Window.IsActive(3002) + !Window.IsActive(3003) + !Window.IsActive(3006)</visible>
             <control type="group">

--- a/1080i/MyPVRChannels.xml
+++ b/1080i/MyPVRChannels.xml
@@ -8,7 +8,7 @@
         <include>PVRHeader</include>
 
         <control type="group">
-            <visible>!Window.IsActive(DialogPVRInfo.xml) + !Window.IsActive(pvrchannelguide) + !Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(DialogPVRInfo.xml) + !Window.IsActive(pvrchannelguide) + !Window.IsActive(favouritesbrowser)</visible>
             <include>CommonViewAnimations</include>
             <posx>0</posx>
             <animation type="WindowClose">
@@ -23,7 +23,7 @@
                 <animation effect="slide" start="0" end="428" time="400" tween="sine" easing="inout" condition="ControlGroup(9001).HasFocus">Conditional</animation>
                 <include>ListEndAnimation</include>
                 <control type="group">
-                    <visible>!Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(favouritesbrowser)</visible>
                     <animation type="WindowOpen" condition="!Control.IsVisible(9001)">
                         <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="545" delay="105" />
                         <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="105" />

--- a/1080i/MyPVRGuide.xml
+++ b/1080i/MyPVRGuide.xml
@@ -22,7 +22,7 @@
                     <animation effect="slide" start="0" end="478" time="400" tween="sine" easing="inout" condition="ControlGroup(9001).HasFocus">Conditional</animation>
                     <include>ListEndAnimation</include>
                     <control type="group">
-                        <visible>Control.IsVisible(10) + !Window.IsActive(favourites)</visible>
+                        <visible>Control.IsVisible(10) + !Window.IsActive(favouritesbrowser)</visible>
                         <animation type="WindowOpen" condition="!Control.IsVisible(9001)">
                             <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="650" />
                             <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" />

--- a/1080i/MyPVRRecordings.xml
+++ b/1080i/MyPVRRecordings.xml
@@ -8,7 +8,7 @@
         <include>PVRHeader</include>
 
         <control type="group">
-            <visible>!Window.IsActive(DialogPVRInfo.xml) + !Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(DialogPVRInfo.xml) + !Window.IsActive(favouritesbrowser)</visible>
             <include>CommonViewAnimations</include>
             <posx>0</posx>
             <animation type="WindowClose">
@@ -23,7 +23,7 @@
                 <animation effect="slide" start="0" end="428" time="400" tween="sine" easing="inout" condition="ControlGroup(9001).HasFocus">Conditional</animation>
                 <include>ListEndAnimation</include>
                 <control type="group">
-                    <visible>!Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(favouritesbrowser)</visible>
                     <animation type="WindowOpen" condition="!Control.IsVisible(9001)">
                         <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="545" delay="105" />
                         <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="105" />

--- a/1080i/MyPVRSearch.xml
+++ b/1080i/MyPVRSearch.xml
@@ -8,7 +8,7 @@
         <include>PVRHeader</include>
 
         <control type="group">
-            <visible>!Window.IsActive(DialogPVRInfo.xml) + !Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(DialogPVRInfo.xml) + !Window.IsActive(favouritesbrowser)</visible>
             <include>CommonViewAnimations</include>
             <posx>0</posx>
             <animation type="WindowClose">

--- a/1080i/MyPVRTimers.xml
+++ b/1080i/MyPVRTimers.xml
@@ -8,7 +8,7 @@
         <include>PVRHeader</include>
 
         <control type="group">
-            <visible>!Window.IsActive(DialogPVRInfo.xml) + !Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(DialogPVRInfo.xml) + !Window.IsActive(favouritesbrowser)</visible>
             <include>CommonViewAnimations</include>
             <posx>0</posx>
             <animation type="WindowClose">
@@ -23,7 +23,7 @@
                 <animation effect="slide" start="0" end="428" time="400" tween="sine" easing="inout" condition="ControlGroup(9001).HasFocus">Conditional</animation>
                 <include>ListEndAnimation</include>
                 <control type="group">
-                    <visible>!Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(favouritesbrowser)</visible>
                     <animation type="WindowOpen" condition="!Control.IsVisible(9001)">
                         <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="545" delay="105" />
                         <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="105" />

--- a/1080i/Settings.xml
+++ b/1080i/Settings.xml
@@ -22,7 +22,7 @@
                 <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                 <effect type="zoom" start="100" end="85" time="300" center="960,600" tween="sine" easing="out" />
             </animation>
-            <visible>!Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(favouritesbrowser)</visible>
 
             <control type="image">
                 <description>Shadow</description>

--- a/1080i/SettingsCategory.xml
+++ b/1080i/SettingsCategory.xml
@@ -23,7 +23,7 @@
                 <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                 <effect type="zoom" start="100" end="85" time="300" center="960,600" tween="sine" easing="out" />
             </animation>
-            <visible>!Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(favouritesbrowser)</visible>
             <control type="group">
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="650" />

--- a/1080i/SettingsProfile.xml
+++ b/1080i/SettingsProfile.xml
@@ -20,7 +20,7 @@
                 <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                 <effect type="zoom" start="100" end="85" time="300" center="960,600" tween="sine" easing="out" />
             </animation>
-            <visible>!Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(favouritesbrowser)</visible>
             <control type="group">
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="650" />

--- a/1080i/SkinSettings.xml
+++ b/1080i/SkinSettings.xml
@@ -22,7 +22,7 @@
                 <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                 <effect type="zoom" start="100" end="85" time="300" center="960,600" tween="sine" easing="out" />
             </animation>
-            <visible>!Window.IsActive(favourites)</visible>
+            <visible>!Window.IsActive(favouritesbrowser)</visible>
             <control type="group">
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="650" />

--- a/1080i/ViewtypesAddons.xml
+++ b/1080i/ViewtypesAddons.xml
@@ -7,7 +7,7 @@
     <include name="Viewtype-AddonList">
 
         <control type="group">
-            <visible>Control.IsVisible(50) + !Window.IsActive(addoninformation) + !Window.IsActive(favourites)</visible>
+            <visible>Control.IsVisible(50) + !Window.IsActive(addoninformation) + !Window.IsActive(favouritesbrowser)</visible>
             <include>CommonViewAnimations</include>
             <include>OptionsShutdownAnimation</include>
 
@@ -179,7 +179,7 @@
             <include>FullscreenDimensions</include>
             <include>OptionsShutdownAnimation</include>
             <control type="group">
-                <visible>Control.IsVisible(500) + !Window.IsActive(addoninformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + String.IsEmpty(Window(Home).Property(script.metadata.actors.hasparent)) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(500) + !Window.IsActive(addoninformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + String.IsEmpty(Window(Home).Property(script.metadata.actors.hasparent)) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="650" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" />
@@ -319,7 +319,7 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Control.IsVisible(500) + !Window.IsActive(addoninformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + String.IsEmpty(Window(Home).Property(script.metadata.actors.hasparent)) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(500) + !Window.IsActive(addoninformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + String.IsEmpty(Window(Home).Property(script.metadata.actors.hasparent)) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="545" delay="105" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="105" />

--- a/1080i/ViewtypesMusic.xml
+++ b/1080i/ViewtypesMusic.xml
@@ -5,7 +5,7 @@
     <!-- ========= -->
     <include name="Viewtype-MusicList">
         <control type="group">
-            <visible>Control.IsVisible(50) + !Window.IsActive(musicinformation) + !Window.IsActive(addoninformation) + !Window.IsActive(favourites)</visible>
+            <visible>Control.IsVisible(50) + !Window.IsActive(musicinformation) + !Window.IsActive(addoninformation) + !Window.IsActive(favouritesbrowser)</visible>
             <include>CommonViewAnimations</include>
             <include>OptionsShutdownAnimation</include>
 
@@ -847,7 +847,7 @@
             <include>OptionsShutdownAnimation</include>
             <!-- List Panel -->
             <control type="group">
-                <visible>Control.IsVisible(52) + !Window.IsActive(musicinformation) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(52) + !Window.IsActive(musicinformation) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="750" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" />
@@ -887,7 +887,7 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Control.IsVisible(52) + !Window.IsActive(musicinformation) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(52) + !Window.IsActive(musicinformation) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="575" delay="175" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="175" />
@@ -1010,7 +1010,7 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Control.IsVisible(52) + !Window.IsActive(musicinformation) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(52) + !Window.IsActive(musicinformation) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="645" delay="105" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="105" />
@@ -1370,7 +1370,7 @@
             <include>FullscreenDimensions</include>
             <include>OptionsShutdownAnimation</include>
             <control type="group">
-                <visible>Control.IsVisible(53) + !Window.IsActive(musicinformation) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(53) + !Window.IsActive(musicinformation) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="645" delay="105" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="105" />
@@ -1458,7 +1458,7 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Control.IsVisible(53) + !Window.IsActive(musicinformation) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(53) + !Window.IsActive(musicinformation) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="750" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" />
@@ -1504,7 +1504,7 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Control.IsVisible(53) + !Window.IsActive(musicinformation) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(53) + !Window.IsActive(musicinformation) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="575" delay="175" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="175" />
@@ -1651,7 +1651,7 @@
                 </animation>
                 <animation effect="fade" start="0" end="100" time="0" delay="1000" reversible="false">Visible</animation>
                 <animation effect="fade" start="100" end="0" time="0" reversible="false">Hidden</animation>
-                <visible>!Window.IsActive(musicinformation) + Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                <visible>!Window.IsActive(musicinformation) + Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
             </control>
 
             <control type="group">
@@ -1682,7 +1682,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,260" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(musicinformation) + Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(musicinformation) + Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>-372</posx>
                         <control type="image">
@@ -1737,7 +1737,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,260" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(musicinformation) + Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(musicinformation) + Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>1860</posx>
                         <control type="image">
@@ -1792,7 +1792,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,260" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(musicinformation) + Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(musicinformation) + Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>1488</posx>
                         <control type="image">
@@ -1847,7 +1847,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,260" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(musicinformation) + Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(musicinformation) + Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>1116</posx>
                         <control type="image">
@@ -1902,7 +1902,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,260" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(musicinformation) + Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(musicinformation) + Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>744</posx>
                         <control type="image">
@@ -1957,7 +1957,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,260" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(musicinformation) + Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(musicinformation) + Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>372</posx>
                         <control type="image">
@@ -2011,7 +2011,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,260" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(musicinformation) + Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(musicinformation) + Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="image">
                         <description>Reflection</description>
                         <posx>-4</posx>
@@ -2065,7 +2065,7 @@
             </control>
 
             <control type="group">
-                <visible>!Window.IsActive(musicinformation) + Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                <visible>!Window.IsActive(musicinformation) + Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation effect="fade" start="100" end="0" time="0" reversible="false">Hidden</animation>
                 <animation effect="fade" start="0" end="100" time="0" delay="1000" reversible="false">Visible</animation>
                 <control type="fixedlist" id="55">
@@ -2209,7 +2209,7 @@
                 <animation type="WindowClose" reversible="false">
                     <effect type="fade" start="100" end="0" time="200" tween="sine" easing="out" />
                 </animation>
-                <visible>!Window.IsActive(musicinformation) + Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                <visible>!Window.IsActive(musicinformation) + Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                 <control type="group">
                     <animation type="Visible" reversible="false">
                         <effect type="fade" start="0" end="100" time="150" delay="150" tween="sine" easing="in" />
@@ -2278,7 +2278,7 @@
             <include>FullscreenDimensions</include>
             <include>OptionsShutdownAnimation</include>
             <control type="group">
-                <visible>Control.IsVisible(501) + !Window.IsActive(musicinformation) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(501) + !Window.IsActive(musicinformation) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="650" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" />
@@ -2403,7 +2403,7 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Control.IsVisible(501) + !Window.IsActive(musicinformation) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(501) + !Window.IsActive(musicinformation) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="545" delay="105" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="105" />

--- a/1080i/ViewtypesPictures.xml
+++ b/1080i/ViewtypesPictures.xml
@@ -7,7 +7,7 @@
     <include name="Viewtype-PictureList">
 
         <control type="group">
-            <visible>Control.IsVisible(50) + !Window.IsActive(addoninformation) + !Window.IsActive(favourites)</visible>
+            <visible>Control.IsVisible(50) + !Window.IsActive(addoninformation) + !Window.IsActive(favouritesbrowser)</visible>
             <include>CommonViewAnimations</include>
             <include>OptionsShutdownAnimation</include>
 
@@ -245,7 +245,7 @@
             <include>OptionsShutdownAnimation</include>
             <!-- List Panel -->
             <control type="group">
-                <visible>Control.IsVisible(52) + !Window.IsActive(addoninformation) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(52) + !Window.IsActive(addoninformation) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="750" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" />
@@ -462,7 +462,7 @@
                 </animation>
                 <animation effect="fade" start="0" end="100" time="0" delay="1000" reversible="false">Visible</animation>
                 <animation effect="fade" start="100" end="0" time="0" reversible="false">Hidden</animation>
-                <visible>Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
             </control>
 
             <control type="group">
@@ -493,7 +493,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,260" tween="sine" easing="out" />
                     </animation>
-                    <visible>Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                    <visible>Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>-372</posx>
                         <control type="image">
@@ -550,7 +550,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,260" tween="sine" easing="out" />
                     </animation>
-                    <visible>Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                    <visible>Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>1860</posx>
                         <control type="image">
@@ -607,7 +607,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,260" tween="sine" easing="out" />
                     </animation>
-                    <visible>Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                    <visible>Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>1488</posx>
                         <control type="image">
@@ -664,7 +664,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,260" tween="sine" easing="out" />
                     </animation>
-                    <visible>Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                    <visible>Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>1116</posx>
                         <control type="image">
@@ -721,7 +721,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,260" tween="sine" easing="out" />
                     </animation>
-                    <visible>Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                    <visible>Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>744</posx>
                         <control type="image">
@@ -778,7 +778,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,260" tween="sine" easing="out" />
                     </animation>
-                    <visible>Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                    <visible>Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>372</posx>
                         <control type="image">
@@ -834,7 +834,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,260" tween="sine" easing="out" />
                     </animation>
-                    <visible>Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                    <visible>Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="image">
                         <description>Reflection</description>
                         <posx>-4</posx>
@@ -890,7 +890,7 @@
             </control>
 
             <control type="group">
-                <visible>Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation effect="fade" start="100" end="0" time="0" reversible="false">Hidden</animation>
                 <animation effect="fade" start="0" end="100" time="0" delay="1000" reversible="false">Visible</animation>
                 <control type="fixedlist" id="55">
@@ -1037,7 +1037,7 @@
                 <animation type="WindowClose" reversible="false">
                     <effect type="fade" start="100" end="0" time="200" tween="sine" easing="out" />
                 </animation>
-                <visible>Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                 <control type="group">
                     <animation type="Visible" reversible="false">
                         <effect type="fade" start="0" end="100" time="150" delay="150" tween="sine" easing="in" />

--- a/1080i/ViewtypesPrograms.xml
+++ b/1080i/ViewtypesPrograms.xml
@@ -6,7 +6,7 @@
     <include name="Viewtype-ProgramList">
 
         <control type="group">
-            <visible>Control.IsVisible(50) + !Window.IsActive(addoninformation) + !Window.IsActive(1122) + !Window.IsActive(favourites) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(favourites)</visible>
+            <visible>Control.IsVisible(50) + !Window.IsActive(addoninformation) + !Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(favouritesbrowser)</visible>
             <include>CommonViewAnimations</include>
             <include>OptionsShutdownAnimation</include>
 
@@ -336,7 +336,7 @@
             <include>OptionsShutdownAnimation</include>
             <!-- List Panel -->
             <control type="group">
-                <visible>Control.IsVisible(52) + !Window.IsActive(1122) + !Window.IsActive(favourites) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(52) + !Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="750" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" />
@@ -376,7 +376,7 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Control.IsVisible(52) + !Window.IsActive(1122) + !Window.IsActive(favourites) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(52) + !Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="575" delay="175" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="175" />
@@ -491,7 +491,7 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Control.IsVisible(52) + !Window.IsActive(1122) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(52) + !Window.IsActive(1122) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="645" delay="105" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="105" />
@@ -660,7 +660,7 @@
             <include>OptionsShutdownAnimation</include>
             <!-- List Panel -->
             <control type="group">
-                <visible>Control.IsVisible(53) + !Window.IsActive(1122) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(53) + !Window.IsActive(1122) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="750" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" />
@@ -700,7 +700,7 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Control.IsVisible(53) + !Window.IsActive(1122) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(53) + !Window.IsActive(1122) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="575" delay="175" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="175" />
@@ -815,7 +815,7 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Control.IsVisible(53) + !Window.IsActive(1122) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(53) + !Window.IsActive(1122) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="645" delay="105" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="105" />
@@ -983,7 +983,7 @@
             <include>FullscreenDimensions</include>
             <include>OptionsShutdownAnimation</include>
             <control type="group">
-                <visible>Control.IsVisible(54) + !Window.IsActive(1122) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(54) + !Window.IsActive(1122) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="645" delay="105" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="105" />
@@ -1072,7 +1072,7 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Control.IsVisible(54) + !Window.IsActive(1122) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(54) + !Window.IsActive(1122) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="750" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" />
@@ -1118,7 +1118,7 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Control.IsVisible(54) + !Window.IsActive(1122) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(54) + !Window.IsActive(1122) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="575" delay="175" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="175" />
@@ -1272,7 +1272,7 @@
             <include>FullscreenDimensions</include>
             <include>OptionsShutdownAnimation</include>
             <control type="group">
-                <visible>Control.IsVisible(55) + !Window.IsActive(1122) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(55) + !Window.IsActive(1122) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="645" delay="105" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="105" />
@@ -1361,7 +1361,7 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Control.IsVisible(55) + !Window.IsActive(1122) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(55) + !Window.IsActive(1122) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="750" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" />
@@ -1407,7 +1407,7 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Control.IsVisible(55) + !Window.IsActive(1122) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(55) + !Window.IsActive(1122) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="575" delay="175" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="175" />
@@ -1558,7 +1558,7 @@
                 </animation>
                 <animation effect="fade" start="0" end="100" time="0" delay="1000" reversible="false">Visible</animation>
                 <animation effect="fade" start="100" end="0" time="0" reversible="false">Hidden</animation>
-                <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(56)</visible>
+                <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(56)</visible>
             </control>
 
             <control type="group">
@@ -1586,7 +1586,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(56)</visible>
+                    <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(56)</visible>
                     <control type="group">
                         <posx>-492</posx>
                         <control type="group">
@@ -1687,7 +1687,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(56)</visible>
+                    <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(56)</visible>
                     <control type="group">
                         <posx>1476</posx>
                         <control type="group">
@@ -1788,7 +1788,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(56)</visible>
+                    <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(56)</visible>
                     <control type="group">
                         <posx>984</posx>
                         <control type="group">
@@ -1889,7 +1889,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(56)</visible>
+                    <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(56)</visible>
                     <control type="group">
                         <posx>492</posx>
                         <control type="group">
@@ -1992,7 +1992,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(56)</visible>
+                    <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(56)</visible>
                     <control type="image">
                         <posx>-10</posx>
                         <posy>625</posy>
@@ -2069,7 +2069,7 @@
             </control>
 
             <control type="group">
-                <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(56)</visible>
+                <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(56)</visible>
                 <animation effect="fade" start="100" end="0" time="0" reversible="false">Hidden</animation>
                 <animation effect="fade" start="0" end="100" time="0" delay="1000" reversible="false">Visible</animation>
                 <control type="fixedlist" id="56">
@@ -2289,7 +2289,7 @@
                 <animation type="Hidden" reversible="true">
                     <effect type="fade" start="100" end="0" time="250" tween="sine" easing="inout" />
                 </animation>
-                <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(56)</visible>
+                <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(56)</visible>
                 <!--Scrollbar-->
                 <control type="image">
                     <description>Scrollbar background (visible on focus)</description>
@@ -2337,7 +2337,7 @@
                 </animation>
                 <animation effect="fade" start="0" end="100" time="0" delay="1000" reversible="false">Visible</animation>
                 <animation effect="fade" start="100" end="0" time="0" reversible="false">Hidden</animation>
-                <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(57)</visible>
+                <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(57)</visible>
             </control>
 
             <control type="group">
@@ -2368,7 +2368,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(57)</visible>
+                    <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(57)</visible>
                     <control type="group">
                         <posx>-372</posx>
                         <control type="image">
@@ -2423,7 +2423,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(57)</visible>
+                    <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(57)</visible>
                     <control type="group">
                         <posx>1860</posx>
                         <control type="image">
@@ -2478,7 +2478,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(57)</visible>
+                    <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(57)</visible>
                     <control type="group">
                         <posx>1488</posx>
                         <control type="image">
@@ -2533,7 +2533,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(57)</visible>
+                    <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(57)</visible>
                     <control type="group">
                         <posx>1116</posx>
                         <control type="image">
@@ -2588,7 +2588,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(57)</visible>
+                    <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(57)</visible>
                     <control type="group">
                         <posx>744</posx>
                         <control type="image">
@@ -2643,7 +2643,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(57)</visible>
+                    <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(57)</visible>
                     <control type="group">
                         <posx>372</posx>
                         <control type="image">
@@ -2697,7 +2697,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(57)</visible>
+                    <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(57)</visible>
                     <control type="image">
                         <description>Reflection</description>
                         <posx>-4</posx>
@@ -2751,7 +2751,7 @@
             </control>
 
             <control type="group">
-                <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(57)</visible>
+                <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(57)</visible>
                 <animation effect="fade" start="100" end="0" time="0" reversible="false">Hidden</animation>
                 <animation effect="fade" start="0" end="100" time="0" delay="1000" reversible="false">Visible</animation>
                 <control type="fixedlist" id="57">
@@ -2896,7 +2896,7 @@
                 <animation type="WindowClose" reversible="false">
                     <effect type="fade" start="100" end="0" time="200" tween="sine" easing="out" />
                 </animation>
-                <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(57)</visible>
+                <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(57)</visible>
                 <control type="group">
                     <control type="group">
                         <animation type="Visible" reversible="false">
@@ -2974,7 +2974,7 @@
                 </animation>
                 <animation effect="fade" start="0" end="100" time="0" delay="1000" reversible="false">Visible</animation>
                 <animation effect="fade" start="100" end="0" time="0" reversible="false">Hidden</animation>
-                <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(58)</visible>
+                <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(58)</visible>
             </control>
 
             <control type="group">
@@ -3005,7 +3005,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,260" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(58)</visible>
+                    <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(58)</visible>
                     <control type="group">
                         <posx>-372</posx>
                         <control type="image">
@@ -3060,7 +3060,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,260" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(58)</visible>
+                    <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(58)</visible>
                     <control type="group">
                         <posx>1860</posx>
                         <control type="image">
@@ -3115,7 +3115,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,260" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(58)</visible>
+                    <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(58)</visible>
                     <control type="group">
                         <posx>1488</posx>
                         <control type="image">
@@ -3170,7 +3170,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,260" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(58)</visible>
+                    <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(58)</visible>
                     <control type="group">
                         <posx>1116</posx>
                         <control type="image">
@@ -3225,7 +3225,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,260" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(58)</visible>
+                    <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(58)</visible>
                     <control type="group">
                         <posx>744</posx>
                         <control type="image">
@@ -3280,7 +3280,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,260" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(58)</visible>
+                    <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(58)</visible>
                     <control type="group">
                         <posx>372</posx>
                         <control type="image">
@@ -3334,7 +3334,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,260" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(58)</visible>
+                    <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(58)</visible>
                     <control type="image">
                         <description>Reflection</description>
                         <posx>-4</posx>
@@ -3388,7 +3388,7 @@
             </control>
 
             <control type="group">
-                <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(58)</visible>
+                <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(58)</visible>
                 <animation effect="fade" start="100" end="0" time="0" reversible="false">Hidden</animation>
                 <animation effect="fade" start="0" end="100" time="0" delay="1000" reversible="false">Visible</animation>
                 <control type="fixedlist" id="58">
@@ -3533,7 +3533,7 @@
                 <animation type="WindowClose" reversible="false">
                     <effect type="fade" start="100" end="0" time="200" tween="sine" easing="out" />
                 </animation>
-                <visible>!Window.IsActive(1122) + !Window.IsActive(favourites) + Control.IsVisible(58)</visible>
+                <visible>!Window.IsActive(1122) + !Window.IsActive(favouritesbrowser) + Control.IsVisible(58)</visible>
                 <control type="group">
                     <animation type="Visible" reversible="false">
                         <effect type="fade" start="0" end="100" time="150" delay="150" tween="sine" easing="in" />
@@ -3602,7 +3602,7 @@
             <include>FullscreenDimensions</include>
             <include>OptionsShutdownAnimation</include>
             <control type="group">
-                <visible>Control.IsVisible(501) + !Window.IsActive(1122) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(501) + !Window.IsActive(1122) + !Window.IsActive(favouritesbrowser)</visible>
                 <include>ThumbnailAnimationsPanel</include>
                 <control type="image">
                     <description>Shadow</description>
@@ -3758,7 +3758,7 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Control.IsVisible(501) + !Window.IsActive(1122) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(501) + !Window.IsActive(1122) + !Window.IsActive(favouritesbrowser)</visible>
                 <include>ThumbnailAnimationsPoster</include>
                 <animation effect="slide" end="36" time="400" tween="cubic" easing="inout" condition="!Skin.HasSetting(ProgramThumbnailSmall)">Conditional</animation>
                 <control type="image">
@@ -3863,7 +3863,7 @@
             <include>FullscreenDimensions</include>
             <include>OptionsShutdownAnimation</include>
             <control type="group">
-                <visible>Control.IsVisible(502) + !Window.IsActive(1122) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(502) + !Window.IsActive(1122) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="650" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" />
@@ -3966,7 +3966,7 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Control.IsVisible(502) + !Window.IsActive(1122) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(502) + !Window.IsActive(1122) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="545" delay="105" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="105" />

--- a/1080i/ViewtypesVideos.xml
+++ b/1080i/ViewtypesVideos.xml
@@ -6,7 +6,7 @@
     <include name="Viewtype-List">
 
         <control type="group">
-            <visible>Control.IsVisible(50) + !Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(addoninformation) + !Window.IsActive(favourites)</visible>
+            <visible>Control.IsVisible(50) + !Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(addoninformation) + !Window.IsActive(favouritesbrowser)</visible>
             <include>CommonViewAnimations</include>
             <include>OptionsShutdownAnimation</include>
 
@@ -1009,7 +1009,7 @@
 
             <!-- List Panel -->
             <control type="group">
-                <visible>Control.IsVisible(52) + !Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(52) + !Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="750" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" />
@@ -1071,7 +1071,7 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Control.IsVisible(52) + !Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + [Container.Content(Movies) | Container.Content(Videos) | Container.Content(TVShows) | Container.Content(Seasons) | Container.Content(Episodes) | Container.Content(Sets)] + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(52) + !Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + [Container.Content(Movies) | Container.Content(Videos) | Container.Content(TVShows) | Container.Content(Seasons) | Container.Content(Episodes) | Container.Content(Sets)] + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="575" delay="175" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="175" />
@@ -1264,7 +1264,7 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Control.IsVisible(52) + !Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(52) + !Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="645" delay="105" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="105" />
@@ -2053,7 +2053,7 @@
             <include>FullscreenDimensions</include>
             <include>OptionsShutdownAnimation</include>
             <control type="group">
-                <visible>Control.IsVisible(53) + !Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(53) + !Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="645" delay="105" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="105" />
@@ -2182,7 +2182,7 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Control.IsVisible(53) + !Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(53) + !Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="575" delay="175" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" delay="175" />
@@ -2324,7 +2324,7 @@
                 </animation>
                 <animation effect="fade" start="0" end="100" time="0" delay="1000" reversible="false">Visible</animation>
                 <animation effect="fade" start="100" end="0" time="0" reversible="false">Hidden</animation>
-                <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(54) + !Window.IsActive(favourites)</visible>
+                <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(54) + !Window.IsActive(favouritesbrowser)</visible>
             </control>
 
             <control type="group">
@@ -2352,7 +2352,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(54) + !Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(54) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>-492</posx>
                         <control type="group">
@@ -2482,7 +2482,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(54) + !Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(54) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>1476</posx>
                         <control type="group">
@@ -2612,7 +2612,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(54) + !Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(54) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>984</posx>
                         <control type="group">
@@ -2742,7 +2742,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(54) + !Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(54) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>492</posx>
                         <control type="group">
@@ -2874,7 +2874,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(54) + !Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(54) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="image">
                         <posx>-10</posx>
                         <posy>625</posy>
@@ -2979,7 +2979,7 @@
             </control>
 
             <control type="group">
-                <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(54) + !Window.IsActive(favourites)</visible>
+                <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(54) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation effect="fade" start="100" end="0" time="0" reversible="false">Hidden</animation>
                 <animation effect="fade" start="0" end="100" time="0" delay="1000" reversible="false">Visible</animation>
                 <control type="fixedlist" id="54">
@@ -3281,7 +3281,7 @@
                 <animation type="Hidden" reversible="true">
                     <effect type="fade" start="100" end="0" time="250" tween="sine" easing="inout" />
                 </animation>
-                <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(54) + !Window.IsActive(favourites)</visible>
+                <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(54) + !Window.IsActive(favouritesbrowser)</visible>
                 <!--Scrollbar-->
                 <control type="image">
                     <description>Scrollbar background (visible on focus)</description>
@@ -3329,7 +3329,7 @@
                 </animation>
                 <animation effect="fade" start="0" end="100" time="0" delay="1000" reversible="false">Visible</animation>
                 <animation effect="fade" start="100" end="0" time="0" reversible="false">Hidden</animation>
-                <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
             </control>
 
             <control type="group">
@@ -3360,7 +3360,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>-372</posx>
                         <control type="image">
@@ -3422,7 +3422,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>1860</posx>
                         <control type="image">
@@ -3477,7 +3477,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>1488</posx>
                         <control type="image">
@@ -3539,7 +3539,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>1116</posx>
                         <control type="image">
@@ -3601,7 +3601,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>744</posx>
                         <control type="image">
@@ -3663,7 +3663,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="group">
                         <posx>372</posx>
                         <control type="image">
@@ -3724,7 +3724,7 @@
                         <effect type="fade" start="100" end="0" time="300" tween="sine" easing="out" />
                         <effect type="zoom" start="100" end="85" time="300" center="960,360" tween="sine" easing="out" />
                     </animation>
-                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                    <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                     <control type="image">
                         <description>Reflection</description>
                         <posx>-4</posx>
@@ -3785,7 +3785,7 @@
             </control>
 
             <control type="group">
-                <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation effect="fade" start="100" end="0" time="0" reversible="false">Hidden</animation>
                 <animation effect="fade" start="0" end="100" time="0" delay="1000" reversible="false">Visible</animation>
                 <control type="fixedlist" id="55">
@@ -3943,7 +3943,7 @@
                 <animation type="WindowClose" reversible="false">
                     <effect type="fade" start="100" end="0" time="200" tween="sine" easing="out" />
                 </animation>
-                <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(55) + !Window.IsActive(favourites)</visible>
+                <visible>!Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + Control.IsVisible(55) + !Window.IsActive(favouritesbrowser)</visible>
                 <control type="group">
                     <control type="group">
                         <animation type="Visible" reversible="false">
@@ -4069,7 +4069,7 @@
             <include>FullscreenDimensions</include>
             <include>OptionsShutdownAnimation</include>
             <control type="group">
-                <visible>Control.IsVisible(500) + !Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(addoninformation) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(500) + !Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(addoninformation) + !Window.IsActive(favouritesbrowser)</visible>
                 <animation type="WindowOpen">
                     <effect type="slide" start="200" end="0" tween="cubic" easing="out" time="650" />
                     <effect type="fade" start="0" end="100" tween="sine" easing="inout" time="300" />
@@ -4452,7 +4452,7 @@
             <include>FullscreenDimensions</include>
             <include>OptionsShutdownAnimation</include>
             <control type="group">
-                <visible>Control.IsVisible(501) + !Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(501) + !Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(favouritesbrowser)</visible>
                 <include>ThumbnailAnimationsPanel</include>
                 <control type="image">
                     <description>Shadow</description>
@@ -4685,7 +4685,7 @@
                 </control>
             </control>
             <control type="group">
-                <visible>Control.IsVisible(501) + !Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(favourites)</visible>
+                <visible>Control.IsVisible(501) + !Window.IsActive(movieinformation) + !Window.IsActive(script-script.extendedinfo-DialogInfo.xml) + !Window.IsActive(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsActive(favouritesbrowser)</visible>
                 <include>ThumbnailAnimationsPoster</include>
                 <animation effect="slide" end="36" time="400" tween="cubic" easing="inout" condition="!Skin.HasSetting(ThumbnailVideoSmall)">Conditional</animation>
                 <control type="image">

--- a/addon.xml
+++ b/addon.xml
@@ -2,13 +2,12 @@
 <addon id="skin.xperience1080" version="10.0.0-alpha.1" name="Xperience1080" provider-name="xhaggi">
     <requires>
         <import addon="xbmc.gui" version="5.17.0" />
-        <import addon="script.globalsearch" version="9.0.4" />
-        <import addon="script.favourites" version="6.0.1" />
-        <import addon="script.artistslideshow" version="1.8.2" />
-        <import addon="script.toolbox" version="1.0.1" />
-        <import addon="resource.images.studios.white" version="0.0.1"/>
-        <import addon="resource.images.musicgenreicons.grey" version="0.0.5"/>
-        <import addon="resource.images.moviegenreicons.white" version="0.0.5"/>
+        <import addon="script.globalsearch" version="9.0.7" />
+        <import addon="script.favourites" version="8.1.2" />
+        <import addon="script.artistslideshow" version="3.3.6" />
+        <import addon="script.toolbox" version="2.0.0" />
+        <import addon="resource.images.studios.white" version="0.0.30"/>
+        <import addon="resource.images.musicgenreicons.grey" version="0.0.6"/>
         <import addon="resource.images.weatherfanart.multi" version="0.0.6"/>
     </requires>
     <extension point="xbmc.gui.skin" effectslowdown="0.80" debugging="false">


### PR DESCRIPTION
- addon versions bumped
- favourites window updated to support Kodi 21
- changelog added
- version schema changed to `0.21.0` to be able to align it with a Kodi version
- removed redundant dependencies call in the AddonInfo to fix confusing right button behavior and to prepare changelog support for the AddonInfo window
- tested with Kodi `21.1.0` on macOS and OSMC `2024.10-1` (`21.1`) on a Vero 4K
<img width="636" alt="grafik" src="https://github.com/user-attachments/assets/79678be9-306d-4437-8a9b-523f0c18aa6a" />
